### PR TITLE
Fix async imports for delivery edit page

### DIFF
--- a/app/admin/deliveries/DeliveryEditForm.tsx
+++ b/app/admin/deliveries/DeliveryEditForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DeliveryForm } from "@/app/admin/DeliveryForm";
+import { DeliveryForm } from "@/app/admin/deliveries/DeliveryForm";
 import { updateDelivery } from "@/app/admin/deliveries/actions";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 

--- a/app/admin/deliveries/[id]/edit/page.tsx
+++ b/app/admin/deliveries/[id]/edit/page.tsx
@@ -1,10 +1,11 @@
 import { Header } from "@/app/components/header";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
-import { DeliveryEditForm } from "./DeliveryEditForm";
+import { notFound } from "next/navigation";
+import { DeliveryEditForm } from "../../DeliveryEditForm";
 
-export default function EditDeliveryPage({ params }: { params: { id: string } }) {
-  const supabase = createSupabaseServerClient();
+export default async function EditDeliveryPage({ params }: { params: { id: string } }) {
+  const supabase = await createSupabaseServerClient();
   const { data: delivery, error } = await supabase
     .from("deliveries")
     .select("*")

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,3 +1,4 @@
-feat: Separate DeliveryEditForm into client component
+fix: restore async fetch and import path for delivery edit page
 
-- Extracted the delivery edit form into a new client component (`DeliveryEditForm.tsx`) to resolve "use server" related build errors in the page component.
+- Update DeliveryEditForm import path to reference deliveries folder
+- Reintroduce async server client creation and notFound handling in EditDeliveryPage


### PR DESCRIPTION
## Summary
- import DeliveryForm from the correct path
- re-add async Supabase client usage in delivery edit page
- update commit message documentation

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870997828dc833387ced5772f726e1f