### PR TITLE
fix: move schemas out of server action files

### DIFF
--- a/app/admin/deliveries/DeliveryForm.tsx
+++ b/app/admin/deliveries/DeliveryForm.tsx
@@ -8,7 +8,7 @@ import { useForm } from "react-hook-form"
 import { z } from "zod"
 import { useEffect, useState } from "react"
 
-import { DeliverySchema } from "./actions"
+import { DeliverySchema } from "./schema"
 import { Button } from "@/components/ui/button"
 import { Calendar } from "@/components/ui/calendar"
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"

--- a/app/admin/deliveries/actions.ts
+++ b/app/admin/deliveries/actions.ts
@@ -3,29 +3,7 @@
 import { createSupabaseServerClient } from '@/lib/supabase/server'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { z } from 'zod'
-
-// Zod schema for validation
-export const DeliverySchema = z.object({
-  title: z.string().min(1, '案件名は必須です。'),
-  customer_name: z.string().min(1, '顧客名は必須です。'),
-  delivery_address: z.string().min(1, '配送先住所は必須です。'),
-  scheduled_at: z.string().optional().nullable(), // Date as string
-  status: z.enum(['pending', 'in_progress', 'completed', 'cancelled']),
-  assigned_driver_id: z.string().uuid().optional().nullable(), // UUID for user
-  assigned_vehicle_id: z.string().uuid().optional().nullable(), // UUID for vehicle
-
-  base_charge: z.coerce.number().min(0, '基本料金は0以上である必要があります。').optional().default(0),
-  distance_charge: z.coerce.number().min(0, '距離料金は0以上である必要があります。').optional().default(0),
-  weight_charge: z.coerce.number().min(0, '重量料金は0以上である必要があります。').optional().default(0),
-  item_count_charge: z.coerce.number().min(0, '個数料金は0以上である必要があります。').optional().default(0),
-
-  invoice_status: z.enum(['unbilled', 'billed', 'paid']).optional().default('unbilled'),
-  billed_at: z.string().optional().nullable(), // Date as string
-  paid_at: z.string().optional().nullable(), // Date as string
-
-  notes: z.string().optional(),
-})
+import { DeliverySchema } from './schema'
 
 export async function addDelivery(formData: FormData) {
   const supabase = await createSupabaseServerClient()

--- a/app/admin/deliveries/schema.ts
+++ b/app/admin/deliveries/schema.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+
+export const DeliverySchema = z.object({
+  title: z.string().min(1, '案件名は必須です。'),
+  customer_name: z.string().min(1, '顧客名は必須です。'),
+  delivery_address: z.string().min(1, '配送先住所は必須です。'),
+  scheduled_at: z.string().optional().nullable(), // Date as string
+  status: z.enum(['pending', 'in_progress', 'completed', 'cancelled']),
+  assigned_driver_id: z.string().uuid().optional().nullable(), // UUID for user
+  assigned_vehicle_id: z.string().uuid().optional().nullable(), // UUID for vehicle
+
+  base_charge: z.coerce
+    .number()
+    .min(0, '基本料金は0以上である必要があります。')
+    .optional()
+    .default(0),
+  distance_charge: z.coerce
+    .number()
+    .min(0, '距離料金は0以上である必要があります。')
+    .optional()
+    .default(0),
+  weight_charge: z.coerce
+    .number()
+    .min(0, '重量料金は0以上である必要があります。')
+    .optional()
+    .default(0),
+  item_count_charge: z.coerce
+    .number()
+    .min(0, '個数料金は0以上である必要があります。')
+    .optional()
+    .default(0),
+
+  invoice_status: z.enum(['unbilled', 'billed', 'paid'])
+    .optional()
+    .default('unbilled'),
+  billed_at: z.string().optional().nullable(), // Date as string
+  paid_at: z.string().optional().nullable(), // Date as string
+
+  notes: z.string().optional(),
+})

--- a/app/admin/vehicles/VehicleForm.tsx
+++ b/app/admin/vehicles/VehicleForm.tsx
@@ -7,7 +7,7 @@ import { useFormStatus } from "react-dom"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 
-import { VehicleSchema } from "./actions"
+import { VehicleSchema } from "./schema"
 import { Button } from "@/components/ui/button"
 import { Calendar } from "@/components/ui/calendar"
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"

--- a/app/admin/vehicles/actions.ts
+++ b/app/admin/vehicles/actions.ts
@@ -3,18 +3,7 @@
 import { createSupabaseServerClient } from '@/lib/supabase/server'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { z } from 'zod'
-
-// Zodを使用して、入力データのバリデーションスキーマを定義
-export const VehicleSchema = z.object({
-  name: z.string().min(1, '車両名は必須です。'),
-  license_plate: z.string().optional(),
-  status: z.enum(['available', 'in_use', 'maintenance']),
-  // 日付は文字列として受け取り、後で変換
-  inspection_due_date: z.string().optional().nullable(),
-  last_maintenance_date: z.string().optional().nullable(),
-  notes: z.string().optional(),
-})
+import { VehicleSchema } from './schema'
 
 export async function addVehicle(formData: FormData) {
   const supabase = await createSupabaseServerClient()

--- a/app/admin/vehicles/schema.ts
+++ b/app/admin/vehicles/schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export const VehicleSchema = z.object({
+  name: z.string().min(1, '車両名は必須です。'),
+  license_plate: z.string().optional(),
+  status: z.enum(['available', 'in_use', 'maintenance']),
+  // 日付は文字列として受け取り、後で変換
+  inspection_due_date: z.string().optional().nullable(),
+  last_maintenance_date: z.string().optional().nullable(),
+  notes: z.string().optional(),
+})


### PR DESCRIPTION
## Summary
- move `DeliverySchema` and `VehicleSchema` to dedicated files
- update forms and actions to import schemas from the new modules

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: unable to fetch fonts from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_6870a8dc65d48333a3b35d33897ecc68